### PR TITLE
Don't added first/last classes if they already exist

### DIFF
--- a/lib/makeColumn.js
+++ b/lib/makeColumn.js
@@ -35,9 +35,9 @@ module.exports = function(col) {
   // Add the basic "columns" class also
   classes.push('columns');
 
-  // Determine if it's the first or last column, or both
-  if (!$(col).prev(this.components.columns).length) classes.push('first');
-  if (!$(col).next(this.components.columns).length) classes.push('last');
+  // Determine if it's the first or last column, or both. Don't add these classes if they already exist.
+  if (!$(col).prev(this.components.columns).length && classes.indexOf('first') === -1 && classes.indexOf('last') === -1) classes.push('first');
+  if (!$(col).next(this.components.columns).length && classes.indexOf('first') === -1 && classes.indexOf('last') === -1) classes.push('last');
 
   // If the column contains a nested row, the .expander class should not be used
   // The == on the first check is because we're comparing a string pulled from $.attr() to a number


### PR DESCRIPTION
Fix issue where first/last classes are added even if they already exist in an element.

This fixes https://github.com/zurb/foundation-emails/issues/760