### PR TITLE
More accessible emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ convertedHtml.html();
 
 ## Accessibility
 
-Since the tables in the generated HTML are purly for styling purpouses, we add the WAI-ARIA `role="presentation"` to them. This ensures that someone using a screen reader doesn't get confused by the quantum of nested tables with no useful semantics and only the important information gets to them.
+Since the tables in Inky's generated HTML are purely for styling purposes, we add the WAI-ARIA `role="presentation"` to them. This ensures that someone using a screen reader doesn't get confused by the quantum of nested tables with no useful semantics and only the important information gets to them.

--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Give Inky simple HTML like this:
 And get complicated, but battle-tested, email-ready HTML like this:
 
 ```html
-<table class="row">
+<table class="row" role="presentation">
   <tbody>
     <tr>
       <th class="small-12 large-6 columns first">
-        <table>
+        <table role="presentation">
           <tr>
             <th class="expander"></th>
           </tr>
         </table>
       </th>
       <th class="small-12 large-6 columns first">
-        <table>
+        <table role="presentation">
           <tr>
             <th class="expander"></th>
           </tr>
@@ -132,3 +132,7 @@ var convertedHtml = i.releaseTheKraken(html);
 // The return value is a Cheerio object. Get the string value with .html()
 convertedHtml.html();
 ```
+
+## Accessibility
+
+Since the tables in the generated HTML are purly for styling purpouses, we add the WAI-ARIA `role="presentation"` to them. This ensures that someone using a screen reader doesn't get confused by the quantum of nested tables with no useful semantics and only the important information gets to them.

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -21,7 +21,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="%s"><tbody><tr>%s</tr></tbody></table>', classes.join(' '), inner);
+      return format('<table class="%s" role="presentation"><tbody><tr>%s</tr></tbody></table>', classes.join(' '), inner);
 
     // <button>
     case this.components.button:
@@ -44,7 +44,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="%s"><tr><td><table><tr><td>%s</td></tr></table></td>%s</tr></table>', classes.join(' '), inner, expander);
+      return format('<table class="%s" role="presentation"><tr><td><table role="presentation"><tr><td>%s</td></tr></table></td>%s</tr></table>', classes.join(' '), inner, expander);
 
     // <container>
     case this.components.container:
@@ -53,7 +53,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="%s"><tbody><tr><td>%s</td></tr></tbody></table>', classes.join(' '), inner);
+      return format('<table class="%s" role="presentation"><tbody><tr><td>%s</td></tr></tbody></table>', classes.join(' '), inner);
 
     // <inky>
     case this.components.inky:
@@ -65,7 +65,7 @@ module.exports = function(element) {
       if (element.attr('class')) {
         classes = classes.concat(element.attr('class').split(' '));
       }
-      return format('<table class="%s"><tr>%s</tr></table>', classes.join(' '), inner);
+      return format('<table class="%s" role="presentation"><tr>%s</tr></table>', classes.join(' '), inner);
 
     // <menu>
     case this.components.menu:
@@ -74,7 +74,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
       var centerAttr = element.attr('align') ? 'align="center"' : '';
-      return format('<table class="%s"%s><tr><td><table><tr>%s</tr></table></td></tr></table>', classes.join(' '), centerAttr, inner);
+      return format('<table class="%s" role="presentation"%s><tr><td><table role="presentation"><tr>%s</tr></table></td></tr></table>', classes.join(' '), centerAttr, inner);
 
     // <item>
     case this.components.menuItem:
@@ -105,7 +105,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="callout"><tr><th class="%s">%s</th><th class="expander"></th></tr></table>', classes.join(' '), inner);
+      return format('<table class="callout" role="presentation"><tr><th class="%s">%s</th><th class="expander"></th></tr></table>', classes.join(' '), inner);
 
     // <spacer>
     case this.components.spacer:
@@ -118,7 +118,7 @@ module.exports = function(element) {
         size = (element.attr('size'));
       }
 
-      return format('<table class="%s"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', classes.join(' '), inner);
+      return format('<table class="%s" role="presentation"><tbody><tr><td height="'+size+'px" style="font-size:'+size+'px;line-height:'+size+'px;">&#xA0;</td></tr></tbody></table>', classes.join(' '), inner);
 
     // <wrapper>
     case this.components.wrapper:
@@ -127,7 +127,7 @@ module.exports = function(element) {
         classes = classes.concat(element.attr('class').split(' '));
       }
 
-      return format('<table class="%s" align="center"><tr><td class="wrapper-inner">%s</td></tr></table>', classes.join(' '), inner);
+      return format('<table class="%s" role="presentation" align="center"><tr><td class="wrapper-inner">%s</td></tr></table>', classes.join(' '), inner);
 
     default:
       // If it's not a custom component, return it as-is

--- a/lib/makeColumn.js
+++ b/lib/makeColumn.js
@@ -45,7 +45,7 @@ module.exports = function(col) {
   // Final HTML output
   output = multiline(function() {/*
     <th class="%s">
-      <table>
+      <table role="presentation">
         <tr>
           <th>%s</th>%s
         </tr>

--- a/test/components.js
+++ b/test/components.js
@@ -45,10 +45,10 @@ describe('Center', () => {
 
     var expected = `
       <center data-parsed="">
-        <table class="menu float-center" align="center">
+        <table class="menu float-center" role="presentation" align="center">
           <tr>
             <td>
-              <table>
+              <table role="presentation">
                 <tr>
                   <th class="menu-item float-center">
                     <a href="#"></a>
@@ -69,10 +69,10 @@ describe('Button', () => {
   it('creates a simple button', () => {
     var input = '<button href="http://zurb.com">Button</button>';
     var expected = `
-      <table class="button">
+      <table class="button" role="presentation">
         <tr>
           <td>
-            <table>
+            <table role="presentation">
               <tr>
                 <td><a href="http://zurb.com">Button</a></td>
               </tr>
@@ -90,10 +90,10 @@ describe('Button', () => {
       <button class="small alert" href="http://zurb.com">Button</button>
     `;
     var expected = `
-      <table class="button small alert">
+      <table class="button small alert" role="presentation">
         <tr>
           <td>
-            <table>
+            <table role="presentation">
               <tr>
                 <td><a href="http://zurb.com">Button</a></td>
               </tr>
@@ -111,10 +111,10 @@ describe('Button', () => {
       <button class="expand" href="http://zurb.com">Button</button>
     `;
     var expected = `
-      <table class="button expand">
+      <table class="button expand" role="presentation">
         <tr>
           <td>
-            <table>
+            <table role="presentation">
               <tr>
                 <td>
                   <center data-parsed=""><a href="http://zurb.com" align="center" class="float-center">Button</a></center>
@@ -139,10 +139,10 @@ describe('Menu', () => {
       </menu>
     `;
     var expected = `
-      <table class="menu">
+      <table class="menu" role="presentation">
         <tr>
           <td>
-            <table>
+            <table role="presentation">
               <tr>
                 <th class="menu-item"><a href="http://zurb.com">Item</a></th>
               </tr>
@@ -161,10 +161,10 @@ describe('Menu', () => {
       </menu>
     `;
     var expected = `
-      <table class="menu vertical">
+      <table class="menu vertical" role="presentation">
         <tr>
           <td>
-            <table>
+            <table role="presentation">
               <tr>
               </tr>
             </table>
@@ -183,10 +183,10 @@ describe('Menu', () => {
       </menu>
     `;
     var expected = `
-      <table class="menu">
+      <table class="menu" role="presentation">
         <tr>
           <td>
-            <table>
+            <table role="presentation">
               <tr>
                 <th class="menu-item"><a href="http://zurb.com">Item 1</a></th>
               </tr>
@@ -204,7 +204,7 @@ describe('Callout', () => {
   it('creates a callout with correct syntax', () => {
     var input = '<callout>Callout</callout>';
     var expected = `
-      <table class="callout">
+      <table class="callout" role="presentation">
         <tr>
           <th class="callout-inner">Callout</th>
           <th class="expander"></th>
@@ -218,7 +218,7 @@ describe('Callout', () => {
   it('copies classes to the final HTML', () => {
     var input = '<callout class="primary">Callout</callout>';
     var expected = `
-      <table class="callout">
+      <table class="callout" role="presentation">
         <tr>
           <th class="callout-inner primary">Callout</th>
           <th class="expander"></th>
@@ -229,12 +229,12 @@ describe('Callout', () => {
     compare(input, expected);
   });
 });
-  
+
 describe('Spacer', () => {
   it('creates a spacer element with correct size', () => {
     var input = '<spacer size="10"></spacer>';
     var expected = `
-      <table class="spacer">
+      <table class="spacer" role="presentation">
         <tbody>
           <tr>
             <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
@@ -245,11 +245,11 @@ describe('Spacer', () => {
 
     compare(input, expected);
   });
-  
+
   it('copies classes to the final spacer HTML', () => {
     var input = '<spacer size="10" class="bgcolor"></spacer>';
     var expected = `
-      <table class="spacer bgcolor">
+      <table class="spacer bgcolor" role="presentation">
         <tbody>
           <tr>
             <td height="10px" style="font-size:10px;line-height:10px;">&#xA0;</td>
@@ -266,7 +266,7 @@ describe('wrapper', () => {
   it('creates a wrapper that you can attach classes to', () => {
     var input = `<wrapper class="header"></wrapper>`;
     var expected = `
-      <table class="wrapper header" align="center">
+      <table class="wrapper header" role="presentation" align="center">
         <tr>
           <td class="wrapper-inner"></td>
         </tr>

--- a/test/grid.js
+++ b/test/grid.js
@@ -16,7 +16,7 @@ describe('Container', () => {
       <html>
         <head></head>
         <body>
-          <table class="container">
+          <table class="container" role="presentation">
             <tbody>
               <tr>
                 <td></td>
@@ -32,7 +32,7 @@ describe('Container', () => {
   it('creates a container table', () => {
     var input = '<container></container>';
     var expected = `
-      <table class="container">
+      <table class="container" role="presentation">
         <tbody>
           <tr>
             <td></td>
@@ -49,7 +49,7 @@ describe('Grid', () => {
   it('creates a row', () => {
     var input = '<row></row>';
     var expected =  `
-      <table class="row">
+      <table class="row" role="presentation">
         <tbody>
           <tr></tr>
         </tbody>
@@ -63,7 +63,7 @@ describe('Grid', () => {
     var input = '<columns large="12" small="12">One</columns>';
     var expected = `
       <th class="small-12 large-12 columns first last">
-        <table>
+        <table role="presentation">
           <tr>
             <th>One</th>
             <th class="expander"></th>
@@ -82,14 +82,14 @@ describe('Grid', () => {
     `;
     var expected = `
       <th class="small-12 large-6 columns first">
-        <table>
+        <table role="presentation">
           <tr>
             <th>One</th>
           </tr>
         </table>
       </th>
       <th class="small-12 large-6 columns last">
-        <table>
+        <table role="presentation">
           <tr>
             <th>Two</th>
           </tr>
@@ -108,21 +108,21 @@ describe('Grid', () => {
     `;
     var expected = `
       <th class="small-12 large-4 columns first">
-        <table>
+        <table role="presentation">
           <tr>
             <th>One</th>
           </tr>
         </table>
       </th>
       <th class="small-12 large-4 columns">
-        <table>
+        <table role="presentation">
           <tr>
             <th>Two</th>
           </tr>
         </table>
       </th>
       <th class="small-12 large-4 columns last">
-        <table>
+        <table role="presentation">
           <tr>
             <th>Three</th>
           </tr>
@@ -137,7 +137,7 @@ describe('Grid', () => {
     var input = '<columns class="small-offset-8 hide-for-small">One</columns>';
     var expected = `
       <th class="small-offset-8 hide-for-small small-12 large-12 columns first last">
-        <table>
+        <table role="presentation">
           <tr>
             <th>One</th>
             <th class="expander"></th>
@@ -157,14 +157,14 @@ describe('Grid', () => {
     `;
     var expected = `
       <th class="small-4 large-4 columns first">
-        <table>
+        <table role="presentation">
           <tr>
             <th>One</th>
           </tr>
         </table>
       </th>
       <th class="small-8 large-8 columns last">
-        <table>
+        <table role="presentation">
           <tr>
             <th>Two</th>
           </tr>
@@ -182,14 +182,14 @@ describe('Grid', () => {
     `;
     var expected = `
       <th class="small-12 large-4 columns first">
-        <table>
+        <table role="presentation">
           <tr>
             <th>One</th>
           </tr>
         </table>
       </th>
       <th class="small-12 large-8 columns last">
-        <table>
+        <table role="presentation">
           <tr>
             <th>Two</th>
           </tr>
@@ -203,14 +203,14 @@ describe('Grid', () => {
   it('supports nested grids', () => {
     var input = '<row><columns><row></row></columns></row>'
     var expected = `
-      <table class="row">
+      <table class="row" role="presentation">
         <tbody>
           <tr>
             <th class="small-12 large-12 columns first last">
-              <table>
+              <table role="presentation">
                 <tr>
                   <th>
-                    <table class="row">
+                    <table class="row" role="presentation">
                       <tbody>
                         <tr></tr>
                       </tbody>
@@ -232,7 +232,7 @@ describe('Block Grid', () => {
   it('returns the correct block grid syntax', () => {
     var input = '<block-grid up="4"></block-grid>';
     var expected = `
-      <table class="block-grid up-4">
+      <table class="block-grid up-4" role="presentation">
         <tr></tr>
       </table>
     `;
@@ -243,7 +243,7 @@ describe('Block Grid', () => {
   it('copies classes to the final HTML output', () => {
     var input = '<block-grid up="4" class="show-for-large"></block-grid>';
     var expected = `
-      <table class="block-grid up-4 show-for-large">
+      <table class="block-grid up-4 show-for-large" role="presentation">
         <tr></tr>
       </table>
     `;

--- a/test/inky.js
+++ b/test/inky.js
@@ -29,7 +29,7 @@ describe('Inky', () => {
   it(`doesn't choke on inline elements`, () => {
     var input = '<container>This is a link to <a href="#">ZURB.com</a>.</container>';
     var expected = `
-      <table class="container">
+      <table class="container" role="presentation">
         <tbody>
           <tr>
             <td>This is a link to <a href="#">ZURB.com</a>.</td>
@@ -44,7 +44,7 @@ describe('Inky', () => {
   it(`doesn't choke on special characters`, () => {
     var input = '<container>This is a link tö <a href="#">ZURB.com</a>.</container>';
     var expected = `
-      <table class="container">
+      <table class="container" role="presentation">
         <tbody>
           <tr>
             <td>This is a link tö <a href="#">ZURB.com</a>.</td>
@@ -59,7 +59,7 @@ describe('Inky', () => {
   it(`doesn't convert these characters into entities`, () => {
     var input = "<container>There's &nbsp; some amazing things here!</container>";
     var expected = `
-      <table class="container">
+      <table class="container" role="presentation">
         <tbody>
           <tr>
             <td>There's &nbsp; some amazing things here!</td>
@@ -74,7 +74,7 @@ describe('Inky', () => {
   it(`doesn't decode entities if non default cheerio config is given`, () => {
     var input = '<container>"should not replace quotes"</container>';
     var expected = `
-      <table class="container">
+      <table class="container" role="presentation">
         <tbody>
           <tr>
             <td>"should not replace quotes"</td>


### PR DESCRIPTION
## Problem
The tables in Inky's generated HTML are purely for styling purposes. For someone using a screen reader it gets really messy to understand the email ([video demo](http://blog.gorebel.com/accessibility-in-email-part-ii/)).

## Solution
Just add the WAI-ARIA `role="presentation"` to all the generated `<table>`s.

## Solves
https://github.com/zurb/foundation-emails/issues/728

## Resources
http://blog.gorebel.com/accessibility-in-email-part-ii/
https://css-tricks.com/html-email-accessibility/#article-header-id-0