### PR TITLE
Fixes #120 - Updates vinyl-fs to latest version 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mkdirp": "^0.5.1",
     "object-values": "^1.0.0",
     "through2": "^2.0.0",
-    "vinyl-fs": "^2.3.0"
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
     "assert-html-equal": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inky",
-  "version": "1.3.8",
+  "version": "1.3.7",
   "description": "Convert a simple HTML syntax into tables compatible with Foundation for Emails.",
   "author": "ZURB <foundation@zurb.com> (http://foundation.zurb.com)",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inky",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Convert a simple HTML syntax into tables compatible with Foundation for Emails.",
   "author": "ZURB <foundation@zurb.com> (http://foundation.zurb.com)",
   "keywords": [


### PR DESCRIPTION
Fixes #120 

Dependabot has recently been natively pulled into Github and is flagging `braces` package as a security vulnerability. This is a dependency of `vinyl-fs` and has been flagged in issue #120 

## Proposal
Update `vinyl-fs` to `3.0.3`. This updates the `glob-stream` dependency to `6.1.0`, which removes the dependency on `micromatch` and `braces` which has the vulnerability.

![image](https://user-images.githubusercontent.com/38262647/84391578-04b74400-abae-11ea-9d9d-81f4e4a10015.png)

Other uses of `braces` are using newer versions 👍

![image](https://user-images.githubusercontent.com/38262647/84392388-2cf37280-abaf-11ea-80b9-9e59a6ead159.png)


## Context
Issue #120 
> Hello Inky maintaining team,
> 
> I started using Inky in a project and running `npm audit` I realised that there is a vulnerability in a dependency chain. Here is the audit result of project using `inky@^1.3.7`:
> 
> ```
> ┌───────────────┬──────────────────────────────────────────────────────────────┐
> │ Low           │ Regular Expression Denial of Service                         │
> ├───────────────┼──────────────────────────────────────────────────────────────┤
> │ Package       │ braces                                                       │
> ├───────────────┼──────────────────────────────────────────────────────────────┤
> │ Patched in    │ >=2.3.1                                                      │
> ├───────────────┼──────────────────────────────────────────────────────────────┤
> │ Dependency of │ inky                                                         │
> ├───────────────┼──────────────────────────────────────────────────────────────┤
> │ Path          │ inky > vinyl-fs > glob-stream > micromatch > braces          │
> ├───────────────┼──────────────────────────────────────────────────────────────┤
> │ More info     │ https://npmjs.com/advisories/786                             │
> └───────────────┴──────────────────────────────────────────────────────────────┘
> ```
> 
> I was looking for the best approach to fix that and seems that updating `vinyl-fs` to 3.0.* will do the trick: every other 2.* versions use a vulnerable version of braces at the end, and 3 doesn't. Since it's a major update I suppose the team need to check if there's some change to do to make it still working.
> 
> If possible, I can contribute with code too, since I'm interested on see this working in a project that have a vulnerabilities check at their pipeline.


Additional context:

### Security vulnerability
![image](https://user-images.githubusercontent.com/38262647/84390835-f9afe400-abac-11ea-9c30-c8b347cf9dcd.png)

### Packages affected
![image](https://user-images.githubusercontent.com/38262647/84390950-28c65580-abad-11ea-9e5b-e14893486b0d.png) |


