### PR TITLE
Change cheerio version to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "browser": "gulp browser"
   },
   "dependencies": {
-    "cheerio": "^0.20.0",
+    "cheerio": "0.22.0",
     "foundation-emails": "^2.2.0",
     "mkdirp": "^0.5.1",
     "object-values": "^1.0.0",


### PR DESCRIPTION
cheerio v0.20.0 or v1.0.0-rc.5 parses incorectly custom self-closing XML tags, e.g:
```
<isinclude template="checkout/confirmation/confirmationEmail"/>
```
will become
```
<isinclude template="checkout/confirmation/confirmationEmail"/></isinclude>
```

And cheerio option `recognizeSelfClosing: false` can't help.

It's fixed only in the stable release of "cheerio" - v0.22.0 (that is used in [inline-css](https://github.com/jonkemp/inline-css)

But `v1.0.0-rc.5` has a`latest` tag so we need to write `"cheerio": "0.22.0"' instead of `"cheerio": "^0.22.0"`